### PR TITLE
Update bower.json with older version of font-awesome to fix bugXXX

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.6",
-    "font-awesome": "~4.5.0"
+    "font-awesome": "~4.4.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.6",
-    "font-awesome": "~4.4.0"
+    "font-awesome": "~4.4.3"
   }
 }


### PR DESCRIPTION
We need to use Font-awesome 4.4.0 because 4.5.0 introduces a bug in component X, you can read more at http://font-awesome.com/bugXXX

Short summary: BugXXX causes `play` icon to be much bigger on IE7,8 and 9, 60x60px instead of 32x32px.
